### PR TITLE
Implement statvfs64 as statvfs (same for f variant)

### DIFF
--- a/src/libc/sys/mount.c
+++ b/src/libc/sys/mount.c
@@ -82,7 +82,21 @@ int shim_statfs64_impl(const char* path, linux_statfs64* linux_buf) {
   return err;
 }
 
+#include <errno.h>
+#include <sys/statvfs.h>
+int shim_statvfs64_impl(const char* path, void* buf)
+{
+  return statvfs(path, buf);
+}
+
+int shim_fstatvfs64_impl(int fd, void* buf)
+{
+  return fstatvfs(fd, buf);
+}
+
 SHIM_WRAP(fstatfs);
 SHIM_WRAP(fstatfs64);
+SHIM_WRAP(fstatvfs64);
 SHIM_WRAP(statfs);
 SHIM_WRAP(statfs64);
+SHIM_WRAP(statvfs64);

--- a/src/prototypes.rb
+++ b/src/prototypes.rb
@@ -289,6 +289,12 @@ define(["sys/param.h", "sys/mount.h", ("sys/statfs.h" if LINUX)].compact, [
   "int fstatfs(int fd, struct statfs* buf)"
 ])
 
+# STATVFS
+define(["sys/param.h", "sys/mount.h", ("sys/statvfs.h" if LINUX)].compact, [
+  "int statvfs64(const char* path, void* buf)",
+  "int fstatvfs64(int fd, void* buf)"
+])
+
 # TRUNCATE(2)
 define(["unistd.h"], [
   "int truncate(const char* path, off_t length)",


### PR DESCRIPTION
When trying to launch dota2 under wine (I am using a too recent amd graphics cards, so I cannot have gpu acceleration on linuxulator), it will simply abort when a game is launch (at the hero selection part).
Apparently just before loading the hero selection screen, dota2 inspect the base directory of the steam games folder by using statvfs64 (I guess it is wine that use it for some windows api).

Having a dummy implementation that return an error is not sufficient since dota2 will just abort, so we need to have some kind of result. I simply use the non extended variant to accomplish this goal. A more elegant way would have been to create the correct structure for statvfs and then copy it for the statvfs64, but I am too lazy and it seems to works.

Note that while it is possible to play dota2 games with wine, it may crash randomly (I get some futex error if I recall). So not really ready for competitive play (I was able to rejoin the game each time, so I guess it is some kind of ok).